### PR TITLE
Update config from `enexSource` to `enexSources` per Yarle v4.2 release

### DIFF
--- a/config.json.in
+++ b/config.json.in
@@ -1,5 +1,7 @@
 {
-    "enexSource": "%DIR%/%NOTEBOOK%",
+    "enexSources": [
+        "%DIR%/%NOTEBOOK%"
+    ],
     "templateFile": "%DIR%/template.tmpl",
     "outputDir": "%DIR%/%TARGET%",
     "isZettelkastenNeeded": false,


### PR DESCRIPTION
As of its [v4.2 release](https://github.com/akosbalasko/yarle/releases/tag/v4.2.0) (on 2021-08-30), Yarle has [dropped support](https://github.com/akosbalasko/yarle/commit/76674788ecae1b5c03bf8bc4014cf18eca1e68c1) for the `enexSource` config in favor of `enexSources` without maintaining any backward-compatible support.

Attempting to run the existing script against the latest Yarle yields an error preventing conversion to Markdown:

```
/usr/local/lib/node_modules/yarle-evernote-to-md/dist/dropTheRopeRunner.js:40
    if (options.enexSources.length === 1 && options.enexSources[0].endsWith('.enex')) {
                            ^

TypeError: Cannot read property 'length' of undefined
    at Object.run (/usr/local/lib/node_modules/yarle-evernote-to-md/dist/dropTheRopeRunner.js:40:29)
    at Object.<anonymous> (/usr/local/lib/node_modules/yarle-evernote-to-md/dist/dropTheRope.js:26:19)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at node:internal/main/run_main_module:17:47
```

This PR updates the `enexSource` config setting to `enexSources` and changes the value to be an array.

*(For back-compatibility with pre-v4.2 versions of Yarle, `config.json.in` could simply output both `enexSource` and `enexSources` and Yarle will use the version appropriate to it. The PR does not take this approach.)*