### PR TITLE
Changed outputFormat to use ObsidianMD

### DIFF
--- a/config.json.in
+++ b/config.json.in
@@ -8,7 +8,7 @@
     "plainTextNotesOnly": false,
     "skipWebClips": false,
     "useHashTags": true,
-    "outputFormat": "StandardMD",
+    "outputFormat": "ObsidianMD",
     "urlEncodeFileNamesAndLinks": false,
     "skipEnexFileNameFromOutputPath": false,
     "haveEnexLevelResources": false,


### PR DESCRIPTION
When converting my notes, my image links were broken in Obsidian. I fixed this by changing the output format of YARLE to "ObsidianMD".