### PR TITLE
Use newest Yarle default config options

### DIFF
--- a/config.json.in
+++ b/config.json.in
@@ -11,13 +11,26 @@
     "outputFormat": "ObsidianMD",
     "urlEncodeFileNamesAndLinks": false,
     "skipEnexFileNameFromOutputPath": false,
-    "haveEnexLevelResources": false,
     "monospaceIsCodeBlock": false,
     "keepMDCharactersOfENNotes": false,
+    "keepOriginalAmountOfNewlines": false,
+    "addExtensionToInternalLinks": true,
     "nestedTags": {
       "separatorInEN": "_",
       "replaceSeparatorWith": "/",
       "replaceSpaceWith": "-"
-   }
+   },
+   "resourcesDir": "_resources",
+   "turndownOptions": {
+      "headingStyle": "atx"
+   },
+   "dateFormat": "YYYY-MM-DD",
+   "haveEnexLevelResources": true,
+   "haveGlobalResources": false,
+    "logseqSettings":{
+        "journalNotes": false
+    },
+   "obsidianSettings": {
+      "omitLinkDisplayName": false
+    }
 }
-


### PR DESCRIPTION
Thanks for the great tool! Unfortunately, it didn't work for me on notes that contained internal links. Updating `config.json.in` with the default options from https://github.com/akosbalasko/yarle/wiki/Configuration fixes that.