### PR TITLE
Fixing Obsidian Frontmatter Tags

### DIFF
--- a/config.json.in
+++ b/config.json.in
@@ -7,7 +7,7 @@
     "isZettelkastenNeeded": false,
     "plainTextNotesOnly": false,
     "skipWebClips": false,
-    "useHashTags": true,
+    "useHashTags": false,
     "outputFormat": "ObsidianMD",
     "urlEncodeFileNamesAndLinks": false,
     "skipEnexFileNameFromOutputPath": false,

--- a/template.tmpl
+++ b/template.tmpl
@@ -1,6 +1,6 @@
 {tags-block}
 ---
-Tag(s): {tags}
+tags: {tags}
 ---
 {end-tags-block}
 {content-block}{content}{end-content-block}


### PR DESCRIPTION
Tags in frontmatter can't have `#` in front of them and need to be on a line called `tags` in order to work (rather than `tag(s)`). See: https://help.obsidian.md/Editing+and+formatting/Tags